### PR TITLE
adding San Antonio, TX

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -1674,7 +1674,7 @@
                 },
                 "san-antonio-texas": {
                     "bbox": {
-                        "top": "29.671,
+                        "top": "29.671",
                         "left": "-98.924",
                         "bottom": "29.194",
                         "right": "-98.085"


### PR DESCRIPTION
adding San Antonio, TX, coordinates taken from the OSM export page (http://www.openstreetmap.org/export#map=11/29.4330/-98.5048)
