### PR TITLE
Additional bounds throughout world

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -202,6 +202,14 @@
                         "right": "74.7624"
                     }
                 },
+                "busan_south-korea": {
+                    "bbox": {
+                        "top": "35.4743",
+                        "left": "128.2466",
+                        "right": "129.4484",
+                        "bottom": "34.9559"
+                    }
+                },
                 "chelyabinsk_russia": {
                     "bbox": {
                         "top": "55.438",
@@ -280,6 +288,14 @@
                         "left": "120.1000",
                         "bottom": "30.2300",
                         "right": "120.1851"
+                    }
+                },
+                "harbin_china": {
+                    "bbox": {
+                        "top": "46.0502",
+                        "right": "127.07",
+                        "left": "126.3572",
+                        "bottom": "45.4221"
                     }
                 },
                 "hiroshima_japan": {
@@ -512,6 +528,14 @@
                         "left": "120.995",
                         "bottom": "24.779",
                         "right": "122.025"
+                    }
+                },
+                "tashkent_uzbekistan": {
+                    "bbox": {
+                        "top": "41.687",
+                        "right": "69.9052",
+                        "left": "68.9191",
+                        "bottom": "41.0473"
                     }
                 },
                 "tokyo_japan": {
@@ -934,6 +958,14 @@
                         "right": "24.433"
                     }
                 },
+                "minsk_belarus": {
+                    "bbox": {
+                        "top": "54.1314",
+                        "right": "27.9614",
+                        "left": "27.1855",
+                        "bottom": "53.6583"
+                    }
+                },
                 "nis_serbia": {
                     "bbox": {
                         "top": "43.359",
@@ -1114,6 +1146,14 @@
                         "right": "-2.555"
                     }
                 },
+                "brescia_italy": {
+                    "bbox": {
+                        "top": "45.7981",
+                        "right": "10.639",
+                        "left": "9.8842",
+                        "bottom": "45.236"
+                    }
+                },
                 "cadiz_spain": {
                     "bbox": {
                         "top": "36.800",
@@ -1208,6 +1248,14 @@
                         "left": "8.860",
                         "bottom": "45.246",
                         "right": "9.470"
+                    }
+                },
+                "naples_italy": {
+                    "bbox": {
+                        "top": "41.3707",
+                        "right": "15.1062",
+                        "left": "13.7741",
+                        "bottom": "40.4031"
                     }
                 },
                 "palermo_italy": {
@@ -1308,6 +1356,14 @@
                         "right": "44.862"
                     }
                 },
+                "baku_azerbaijan": {
+                    "bbox": {
+                        "top": "41.3757",
+                        "right": "50.8387",
+                        "left": "48.7925",
+                        "bottom": "39.3195"
+                    }
+                },
                 "damascus_syria": {
                     "bbox": {
                         "top": "33.805",
@@ -1338,6 +1394,14 @@
                         "left": "34.253",
                         "bottom": "31.356",
                         "right": "34.667"
+                    }
+                },
+                "izmir_turkey": {
+                    "bbox": {
+                        "top": "38.9112",
+                        "right": "27.518",
+                        "left": "26.801",
+                        "bottom": "38.2535"
                     }
                 },
                 "kabul_afghanistan": {
@@ -1395,9 +1459,17 @@
                 "top": "54.213",
                 "left": "-168.400",
                 "bottom": "5.9",
-                "right": "-69.620"
+                "right": "-65"
             },
             "cities": {
+                "albuquerque_new-mexico": {
+                    "bbox": {
+                        "top": "36.220",
+                        "left": "-107.627",
+                        "right": "-105.7145",
+                        "bottom": "34.8690"
+                    }
+                },
                 "atlanta_georgia": {
                     "bbox": {
                         "top": "34.618",
@@ -1702,6 +1774,14 @@
                         "right": "-86.152"
                     }
                 },
+                "monterrey_mexico": {
+                    "bbox": {
+                        "top": "26.0473",
+                        "right": "-99.7513",
+                        "left": "-100.7803",
+                        "bottom": "25.1365"
+                    }
+                },
                 "mexico-city_mexico": {
                     "bbox": {
                         "top": "19.921",
@@ -1790,6 +1870,14 @@
                         "right": "-75.052"
                     }
                 },
+                "panama-city_panama": {
+                    "bbox": {
+                        "top": "9.2107",
+                        "right": "-79.0821",
+                        "left": "-79.7913",
+                        "bottom": "8.7064"
+                    }
+                },
                 "philadelphia_pennsylvania": {
                     "bbox": {
                         "top": "40.308",
@@ -1870,6 +1958,14 @@
                         "right": "-120.995"
                     }
                 },
+                "salt-lake-city_utah": {
+                    "bbox": {
+                        "top": "41.434",
+                        "left": "-112.493",
+                        "right": "-110.857",
+                        "bottom": "39.776"
+                    }
+                },
                 "san-antonio_texas": {
                     "bbox": {
                         "top": "29.671",
@@ -1900,6 +1996,14 @@
                         "left": "-123.640",
                         "bottom": "36.791",
                         "right": "-121.025"
+                    }
+                },
+                "san-juan_puerto-rico": {
+                    "bbox": {
+                        "top": "18.6247",
+                        "right": "-65.7485",
+                        "left": "-66.3528",
+                        "bottom": "18.1525"
                     }
                 },
                 "santa-barbara_california": {
@@ -2090,6 +2194,14 @@
                 "right": "-33.000"
             },
             "cities": {
+                "belo-horizonte_brazil": {
+                    "bbox": {
+                        "top": "-19.5837",
+                        "right": "-43.7471",
+                        "left": "-44.3302",
+                        "bottom": "-20.1668"
+                    }
+                },
                 "bogota_colombia": {
                     "bbox": {
                         "top": "5.022",
@@ -2218,12 +2330,28 @@
                         "right": "-78.100"
                     }
                 },
+                "recife_brazil": {
+                    "bbox": {
+                        "top": "-7.7318",
+                        "right": "-34.5272",
+                        "left": "-35.1576",
+                        "bottom": "-8.4253"
+                    }
+                },
                 "rio-de-janeiro_brazil": {
                     "bbox": {
                         "top": "-22.378",
                         "left": "-43.860",
                         "bottom": "-23.216",
                         "right": "-42.751"
+                    }
+                },
+                "salvador_brazil": {
+                    "bbox": {
+                        "top": "-12.4915",
+                        "right": "-37.8999",
+                        "left": "-38.7825",
+                        "bottom": "-13.2795"
                     }
                 },
                 "sao-paulo_brazil": {


### PR DESCRIPTION
I found these bounds useful for a project, so I'm adding in a few that I generated.

The `bernalillo-county_new-mexico` box doesn't cover the entire Albuquerque urban area. Rather than expand it or alter the existing entry, I've added another bounds that covers both Albuquerque and Santa Fe. If no one is specifically relying on `bernallilo`, I suggest replacing it with the larger `albuquerque`.

Additionally, I stretched the north_america region eastward to encompass San Juan, Puerto Rico.
