### PR TITLE
Increase San Juan, Puerto Rico size

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -2040,10 +2040,10 @@
                 },
                 "san-juan_puerto-rico": {
                     "bbox": {
-                        "top": "18.472",
-                        "left": "-66.125",
-                        "right": "-65.992",
-                        "bottom": "18.298"
+                        "top": "18.502",
+                        "left": "-66.301",
+                        "right": "-65.817",
+                        "bottom": "18.186"
                     }
                 },
                 "santa-barbara_california": {


### PR DESCRIPTION
San Juan, Puerto Rico Metropolitan Area includes many nearby adjacent municipalities. This expansion is quite conservative since judging by U.S. Census standards, the SJ Metro Area includes half the island.
