### PR TITLE
Update cities.json

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -941,7 +941,7 @@
                         "right": "1.779"
                     }
                 },
-                basel_switzerland": {
+                "basel_switzerland": {
                     "bbox": {
                         "top": "47.672",
                         "left": "7.462",
@@ -949,7 +949,7 @@
                         "right": "7.866"
                     }
                 },
-                geneva_switzerland": {
+                "geneva_switzerland": {
                     "bbox": {
                         "top": "46.436",
                         "left": "5.892",


### PR DESCRIPTION
added trinational metro area of Basel, binational metro area of Geneva and expanded the area of Zurich which until now only contained about half the municipality of zurich
