### PR TITLE
BBOX for Barcelona (Spain) is too big. Shrinking to the one used interna...

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -1261,10 +1261,10 @@
                 },
                 "barcelona_spain": {
                     "bbox": {
-                        "top": "41.687",
-                        "left": "1.734",
-                        "bottom": "41.075",
-                        "right": "2.496"
+                        "top": "41.533",
+                        "left": "1.898",
+                        "bottom": "41.246",
+                        "right": "2.312"
                     }
                 },
                 "bilbao_spain": {


### PR DESCRIPTION
BBOX for Barcelona (Spain) is actually too big. Proposal to shrink it to the BBOX used by the metropolitan public transport agency (tmb.cat), which is more reasonable.
