### PR TITLE
extend Managua to the greater capital reagion

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -2225,10 +2225,10 @@
                 },
                 "managua_nicaragua": {
                     "bbox": {
-                        "top": "12.182",
-                        "left": "-86.374",
-                        "bottom": "12.053",
-                        "right": "-86.152"
+                        "top": "12.250",
+                        "left": "-86.451",
+                        "bottom": "11.826",
+                        "right": "-85.935"
                     }
                 },
                 "mcallen_texas" : {


### PR DESCRIPTION
including 
- Carretera Sur (main corridor south)
- Along Carretera Masaya all the way to Granada
- to Tipitapa.
  These are all areas from which there is commuting to Managua .. and given the low amount of data this also just a few Mb anyways.
