### PR TITLE
Expanded: Adelaide, South Australia

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -2763,10 +2763,10 @@
             "cities": {
                 "adelaide_australia": {
                     "bbox": {
-                        "top": "-34.840",
-                        "left": "138.464",
-                        "bottom": "-35.021",
-                        "right": "138.707"
+                        "top": "-34.570",
+                        "left": "138.417",
+                        "bottom": "-35.261",
+                        "right": "138.854"
                     }
                 },
                 "auckland_new-zealand": {


### PR DESCRIPTION
Not so familar with Ruby Jems, so not sure if the tests worked properly or not..
Happy to pull/merge and resubmit pull request.

I'm running Ubuntu 14.10, so some more information in the README on how to do this would be useful.
 Managed to do:
  sudo apt-get install bundler
  sudo apt-get install rake
  bundle exec rake 

preparing sandbox
rm -rf /export/home/paul/git/metroextractor-cities/spec/tmp
mkdir -p /export/home/paul/git/metroextractor-cities/spec/tmp
cp -r Rakefile README.md spec/geojson_spec.rb spec/bbox_spec.rb spec/json_spec.rb spec/whitespace_spec.rb spec/bbox_size_spec.rb spec/ruby_spec.rb tasks/test.rb tasks/build_geojson.rb tasks/default.rb /export/home/paul/git/metroextractor-cities/spec/tmp
Running rubocop
rubocop /export/home/paul/git/metroextractor-cities/spec/tmp
Inspecting 10 files
CCCCCCCCCC

Offenses:

spec/tmp/geojson_spec.rb:2:1: C: Missing utf-8 encoding comment.
spec/tmp/test.rb:2:1: C: Missing utf-8 encoding comment.
spec/tmp/bbox_spec.rb:2:1: C: Missing utf-8 encoding comment.
spec/tmp/build_geojson.rb:2:1: C: Missing utf-8 encoding comment.
spec/tmp/json_spec.rb:2:1: C: Missing utf-8 encoding comment.
spec/tmp/whitespace_spec.rb:2:1: C: Missing utf-8 encoding comment.
spec/tmp/Rakefile:2:1: C: Missing utf-8 encoding comment.
spec/tmp/default.rb:2:1: C: Missing utf-8 encoding comment.
spec/tmp/bbox_size_spec.rb:2:1: C: Missing utf-8 encoding comment.
spec/tmp/ruby_spec.rb:2:1: C: Missing utf-8 encoding comment.

10 files inspected, 10 offenses detected
rake aborted!
Command failed with status (1): [rubocop /export/home/paul/git/metroextract...]
/export/home/paul/git/metroextractor-cities/spec/ruby_spec.rb:12:in `block (2 levels) in <top (required)>'
/export/home/paul/git/metroextractor-cities/tasks/test.rb:4:in`block in <top (required)>'
/export/home/paul/git/metroextractor-cities/tasks/default.rb:4:in `block in <top (required)>'
Tasks: TOP => test:ruby
(See full trace by running task with --trace)
