### PR TITLE
Added Bharatpur municipality of Nepal

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -442,6 +442,14 @@
                         "right": "77.850"
                     }
                 },
+                "bharatpur_nepal": {
+                    "bbox": {
+                        "top": "27.822",
+                        "left": "84.673",
+                        "bottom": "27.518",
+                        "right": "84.158"
+                    }
+                },
                 "bishkek_kyrgyzstan": {
                     "bbox": {
                         "top": "42.986",


### PR DESCRIPTION
Bharatpur is a second biggest city of Nepal after Kathmandu. Lots of mapping work is going on there recently in OpenStreetMap. Over the course of next month 12000 individual buildings will be surveyed in field and the data will be mapped in OSM. Please accept this request to add to the excitement of growing OSM community in Bharatpur. 