### PR TITLE
New bbox for bratislava_slovakia (only, excluding region of Vienna, Austria)

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -1752,6 +1752,14 @@
                         "right": "17.841"
                     }
                 },
+                "bratislava_slovakia": {
+                    "bbox": {
+                        "top": "48.2946",
+                        "left": "16.955",
+                        "bottom": "48.0611",
+                        "right": "17.494"
+                    }
+                },
                 "vilnius_lithuania": {
                     "bbox": {
                         "top": "49.281",

--- a/cities.json
+++ b/cities.json
@@ -1754,9 +1754,9 @@
                 },
                 "bratislava_slovakia": {
                     "bbox": {
-                        "top": "48.2946",
+                        "top": "48.295",
                         "left": "16.955",
-                        "bottom": "48.0611",
+                        "bottom": "48.061",
                         "right": "17.494"
                     }
                 },


### PR DESCRIPTION
Please, pull this addition. 
region: bratislava_slovakia