### PR TITLE
Add Greater Lafayette, IN, US.

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -2776,6 +2776,14 @@
                         "right": "-82.278"
                     }
                 },
+                "lafayette_indiana": {
+                    "bbox": {
+                        "top": "40.520",
+                        "left": "-87.000",
+                        "bottom": "40.330",
+                        "right": "-86.750"
+                    }
+                },
                 "las-vegas_nevada": {
                     "bbox": {
                         "top": "36.615",


### PR DESCRIPTION
Added Greater Lafayette area in Indiana (US) -- includes twin cities [Lafayette](https://en.wikipedia.org/wiki/Lafayette,_Indiana) and [West Lafayette](https://en.wikipedia.org/wiki/West_Lafayette,_Indiana), Indiana.

Test result below.

--

```
$ bundle exec rake
Preparing sandbox
rm -rf /Users/jeffmk/dev/map/metroextractor-cities/spec/tmp
mkdir -p /Users/jeffmk/dev/map/metroextractor-cities/spec/tmp
cp -r Rakefile README.md spec/bbox_numeric_spec.rb spec/bbox_precision_spec.rb spec/bbox_size_spec.rb spec/bbox_spec.rb spec/geojson_spec.rb spec/json_spec.rb spec/ruby_spec.rb spec/whitespace_spec.rb tasks/build_geojson.rb tasks/default.rb tasks/test.rb /Users/jeffmk/dev/map/metroextractor-cities/spec/tmp
Running rubocop
rubocop /Users/jeffmk/dev/map/metroextractor-cities/spec/tmp
Inspecting 12 files
............

12 files inspected, no offenses detected
Checking cities.json for valid bbox's
OK
Validating cities.json bbox sizes
OK
Validating cities.json bbox input is numeric
OK
Validating cities.json bbox input is carried to three decimal places of precision
OK
Validating cities.json syntax
OK
Checking cities.json for invalid whitespace
OK
Validating cities.geojson syntax
OK
```