### PR TITLE
Add Fort Wayne, IN, US.

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -2624,6 +2624,14 @@
                         "right": "-104.987"
                     }
                 },
+                "fort-wayne_indiana": {
+                    "bbox": {
+                        "top": "41.208",
+                        "left": "-85.335",
+                        "bottom": "40.950",
+                        "right": "-84.980"
+                    }
+                },
                 "fredericton_canada": {
                     "bbox": {
                         "top": "46.024",


### PR DESCRIPTION
Added [Fort Wayne](https://en.wikipedia.org/wiki/Fort_Wayne,_Indiana), IN, US.

Test results below.

--

```
$ bundle exec rake
Preparing sandbox
rm -rf /Users/jeffmk/dev/map/metroextractor-cities/spec/tmp
mkdir -p /Users/jeffmk/dev/map/metroextractor-cities/spec/tmp
cp -r Rakefile README.md spec/bbox_numeric_spec.rb spec/bbox_precision_spec.rb spec/bbox_size_spec.rb spec/bbox_spec.rb spec/geojson_spec.rb spec/json_spec.rb spec/ruby_spec.rb spec/whitespace_spec.rb tasks/build_geojson.rb tasks/default.rb tasks/test.rb /Users/jeffmk/dev/map/metroextractor-cities/spec/tmp
Running rubocop
rubocop /Users/jeffmk/dev/map/metroextractor-cities/spec/tmp
Inspecting 12 files
............

12 files inspected, no offenses detected
Checking cities.json for valid bbox's
OK
Validating cities.json bbox sizes
OK
Validating cities.json bbox input is numeric
OK
Validating cities.json bbox input is carried to three decimal places of precision
OK
Validating cities.json syntax
OK
Checking cities.json for invalid whitespace
OK
Validating cities.geojson syntax
OK
```