### PR TITLE
Update cities.json to add Luoyang, China

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -706,6 +706,14 @@
                         "right": "75.425"
                     }
                 },
+                "luoyang_china": {
+                    "bbox": {
+                        "top": "34.761",
+                        "left": "112.282",
+                        "bottom": "34.539",
+                        "right": "112.611"
+                    }
+                },
                 "manila_phillipines": {
                     "bbox": {
                         "top": "14.900",


### PR DESCRIPTION
Luoyang is a city in western Henan province of Central China, and one of the cradles of Chinese civilization, and is one of the Four Great Ancient Capitals of China.

http://en.wikipedia.org/wiki/Luoyang