### PR TITLE
Expand Bruges to cover all of admin_level 8 Brugge

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -1271,10 +1271,10 @@
                 },
                 "bruges_belgium": {
                     "bbox": {
-                        "top": "51.271",
-                        "left": "3.127",
-                        "bottom": "51.144",
-                        "right": "3.296"
+                        "top": "51.374",
+                        "left": "3.107",
+                        "bottom": "51.148",
+                        "right": "3.337"
                     }
                 },
                 "brussels_belgium": {


### PR DESCRIPTION
@KathleenLD sorry to rehash this.  Can we expand Bruges to cover the admin_level = 8 boundary of Brugge?  As per http://www.openstreetmap.org/relation/562654#map=11/51.2608/3.2221 