### PR TITLE
Update json cities

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -3169,6 +3169,14 @@
                         "right": "-120.880"
                     }
                 },
+                "guadalajara_jalisco": {
+                    "bbox": {
+                        "top": "20.840",
+                        "left": "-103.153",
+                        "bottom": "20.440",
+                        "right": "-103.508"
+                    }
+                },
                 "providence_rhode-island": {
                     "bbox": {
                         "top": "41.881",


### PR DESCRIPTION
Adding Guadalaja City, second largest urban zone in Mexico, comprising several counties: Guadalajara, Zapopan, Tlaquepaque, Tonala, Tlajomulco and El Salto