### PR TITLE
add several towns in Hesse and one in Rhineland-Palatinate, Germany

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -1615,6 +1615,14 @@
                         "right": "12.170"
                     }
                 },
+                "gießen_germany": {
+                    "bbox": {
+                        "top": "50.635",
+                        "left": "8.555",
+                        "bottom": "50.526",
+                        "right": "8.764"
+                    }
+                },
                 "glasgow_scotland": {
                     "bbox": {
                         "top": "56.034",

--- a/cities.json
+++ b/cities.json
@@ -1487,6 +1487,14 @@
                         "right": "7.718"
                     }
                 },
+                "darmstadt_germany": {
+                    "bbox": {
+                        "top": "49.954",
+                        "left": "8.559",
+                        "bottom": "49.795",
+                        "right": "8.750"
+                    }
+                },
                 "dijon_france": {
                     "bbox": {
                         "top": "47.364",

--- a/cities.json
+++ b/cities.json
@@ -2047,6 +2047,14 @@
                         "right": "-7.033"
                     }
                 },
+                "wiesbaden_germany": {
+                    "bbox": {
+                        "top": "50.152",
+                        "left": "8.110",
+                        "bottom": "49.993",
+                        "right": "8.386"
+                    }
+                },
                 "basel_switzerland": {
                     "bbox": {
                         "top": "47.672",

--- a/cities.json
+++ b/cities.json
@@ -1775,6 +1775,14 @@
                         "right": "5.517"
                     }
                 },
+                "mainz_germany": {
+                    "bbox": {
+                        "top": "50.035",
+                        "left": "8.110",
+                        "bottom": "49.895",
+                        "right": "8.343"
+                    }
+                },
                 "manchester_england": {
                     "bbox": {
                         "top": "53.672",

--- a/cities.json
+++ b/cities.json
@@ -1591,6 +1591,14 @@
                         "right": "-2.289"
                     }
                 },
+                "fulda_germany": {
+                    "bbox": {
+                        "top": "50.629",
+                        "left": "9.565",
+                        "bottom": "50.499",
+                        "right": "9.732"
+                    }
+                },
                 "marburg_germany": {
                     "bbox": {
                         "top": "50.884",

--- a/cities.json
+++ b/cities.json
@@ -1577,10 +1577,10 @@
                 },
                 "frankfurt_germany": {
                     "bbox": {
-                        "top": "50.447",
-                        "left": "7.811",
-                        "bottom": "49.632",
-                        "right": "9.442"
+                        "top": "50.227",
+                        "left": "8.471",
+                        "bottom": "50.014",
+                        "right": "8.800"
                     }
                 },
                 "frome_england": {

--- a/cities.json
+++ b/cities.json
@@ -1502,7 +1502,7 @@
                         "bottom": "47.256",
                         "right": "5.114"
                     }
-                },                
+                },
                 "derby_england": {
                     "bbox": {
                         "top": "52.968",
@@ -1510,7 +1510,7 @@
                         "bottom": "52.861",
                         "right": "-1.383"
                     }
-                }, 
+                },
                 "derry_ireland": {
                     "bbox": {
                         "top": "55.043",
@@ -1525,7 +1525,7 @@
                         "left": "13.586",
                         "bottom": "50.978",
                         "right": "13.972"
-                    }  
+                    }
                 },
                 "dublin_ireland": {
                     "bbox": {
@@ -1685,6 +1685,14 @@
                         "left": "7.893",
                         "bottom": "48.730",
                         "right": "8.816"
+                    }
+                },
+                "kassel_germany": {
+                    "bbox": {
+                        "top": "51.369",
+                        "left": "9.349",
+                        "bottom": "51.260",
+                        "right": "9.570"
                     }
                 },
                 "lausanne_switzerland": {


### PR DESCRIPTION
This boundary box gets shrunken because it is quite a bit bigger than the actual administrative border:

* Frankfurt

The towns which are meant to be added:

* Darmstadt
* Fulda
* Gießen
* Kassel
* Mainz
* Wiesbaden

In addition to that I removed some unnecessary whitespace.