### PR TITLE
add several towns in south Germany

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -2112,6 +2112,14 @@
                         "right": "6.349"
                     }
                 },
+                "ulm_germany": {
+                    "bbox": {
+                        "top": "48.468",
+                        "left": "9.841",
+                        "bottom": "48.306",
+                        "right": "10.043"
+                    }
+                },
                 "utrecht_netherlands": {
                     "bbox": {
                         "top": "52.184",

--- a/cities.json
+++ b/cities.json
@@ -1890,10 +1890,10 @@
                 }, 
                 "nuremberg_germany": {
                     "bbox": {
-                        "top": "49.757",
-                        "left": "10.697",
-                        "bottom": "49.219",
-                        "right": "11.339"
+                        "top": "49.541",
+                        "left": "10.987",
+                        "bottom": "49.330",
+                        "right": "11.283"
                     }
                 },
                 "paris_france": {

--- a/cities.json
+++ b/cities.json
@@ -1344,6 +1344,14 @@
                         "right": "4.520"
                     }
                 },
+                "augsburg_germany": {
+                    "bbox": {
+                        "top": "48.458",
+                        "left": "10.763",
+                        "bottom": "48.257",
+                        "right": "12.192"
+                    }
+                },
                 "avignon_france": {
                     "bbox": {
                         "top": "43.996",

--- a/cities.json
+++ b/cities.json
@@ -1720,6 +1720,14 @@
                         "right": "11.972"
                     }
                 },
+                "ingolstadt_germany": {
+                    "bbox": {
+                        "top": "48.822",
+                        "left": "11.254",
+                        "bottom": "48.683",
+                        "right": "11.504"
+                    }
+                },
                 "jena_germany": {
                     "bbox": {
                         "top": "50.988",

--- a/cities.json
+++ b/cities.json
@@ -1352,6 +1352,14 @@
                         "right": "4.927"
                     }
                 },
+                "bamberg_germany": {
+                    "bbox": {
+                        "top": "49.928",
+                        "left": "10.826",
+                        "bottom": "49.842",
+                        "right": "10.961"
+                    }
+                },
                 "basel_switzerland": {
                     "bbox": {
                         "top": "47.596",

--- a/cities.json
+++ b/cities.json
@@ -2008,6 +2008,14 @@
                         "right": "-0.901"
                     }
                 },
+                "regensburg_germany": {
+                    "bbox": {
+                        "top": "49.076",
+                        "left": "12.028",
+                        "bottom": "48.966",
+                        "right": "12.192"
+                    }
+                },
                 "rennes_france": {
                     "bbox": {
                         "top": "48.301",

--- a/cities.json
+++ b/cities.json
@@ -1535,7 +1535,15 @@
                         "bottom": "47.256",
                         "right": "5.114"
                     }
-                },                
+                },
+                "deggendorf_germany": {
+                    "bbox": {
+                        "top": "48.908",
+                        "left": "12.873",
+                        "bottom": "48.786",
+                        "right": "13.074"
+                    }
+                },
                 "derby_england": {
                     "bbox": {
                         "top": "52.968",

--- a/cities.json
+++ b/cities.json
@@ -2096,22 +2096,6 @@
                         "right": "10.015"
                     }
                 },
-                "basel_switzerland": {
-                    "bbox": {
-                        "top": "47.672",
-                        "left": "7.462",
-                        "bottom": "47.436",
-                        "right": "7.866"
-                    }
-                },
-                "geneva_switzerland": {
-                    "bbox": {
-                        "top": "46.436",
-                        "left": "5.892",
-                        "bottom": "46.096",
-                        "right": "6.349"
-                    }
-                },
                 "ulm_germany": {
                     "bbox": {
                         "top": "48.468",

--- a/cities.json
+++ b/cities.json
@@ -1728,6 +1728,14 @@
                         "right": "11.972"
                     }
                 },
+                "heilbronn_germany": {
+                    "bbox": {
+                        "top": "49.210",
+                        "left": "9.043",
+                        "bottom": "49.092",
+                        "right": "9.302"
+                    }
+                },
                 "ingolstadt_germany": {
                     "bbox": {
                         "top": "48.822",

--- a/cities.json
+++ b/cities.json
@@ -2064,6 +2064,14 @@
                         "right": "-7.033"
                     }
                 },
+                "würzburg_germany": {
+                    "bbox": {
+                        "top": "49.845",
+                        "left": "9.870",
+                        "bottom": "49.709",
+                        "right": "10.015"
+                    }
+                },
                 "basel_switzerland": {
                     "bbox": {
                         "top": "47.672",

--- a/cities.json
+++ b/cities.json
@@ -1728,6 +1728,14 @@
                         "right": "8.816"
                     }
                 },
+                "konstanz_germany": {
+                    "bbox": {
+                        "top": "47.762",
+                        "left": "9.084",
+                        "bottom": "47.653",
+                        "right": "9.218"
+                    }
+                },
                 "lausanne_switzerland": {
                     "bbox": {
                         "top": "46.587",

--- a/cities.json
+++ b/cities.json
@@ -2031,14 +2031,14 @@
                         "bottom": "48.371",
                         "right": "8.078"
                     }
-				},
-				"the-hague_netherlands": {
-					"bbox": {
-						"top": "52.136",
-						"left": "4.183",
-						"bottom": "52.006",
-						"right": "4.427"
-					}
+                },
+                "the-hague_netherlands": {
+                    "bbox": {
+                        "top": "52.136",
+                        "left": "4.183",
+                        "bottom": "52.006",
+                        "right": "4.427"
+                    }
                 },
                 "toulouse_france": {
                     "bbox": {

--- a/cities.json
+++ b/cities.json
@@ -1952,6 +1952,14 @@
                         "right": "2.911"
                     }
                 },
+                "passau_germany": {
+                    "bbox": {
+                        "top": "48.613",
+                        "left": "13.301",
+                        "bottom": "48.540",
+                        "right": "13.514"
+                    }
+                },
                 "plauen_germany": {
                     "bbox": {
                         "top": "50.574",

--- a/cities.json
+++ b/cities.json
@@ -1640,6 +1640,14 @@
                         "right": "9.442"
                     }
                 },
+                "freiburg_germany": {
+                    "bbox": {
+                        "top": "48.071",
+                        "left": "7.661",
+                        "bottom": "47.902",
+                        "right": "7.931"
+                    }
+                },
                 "frome_england": {
                     "bbox": {
                         "top": "51.250",

--- a/cities.json
+++ b/cities.json
@@ -1890,10 +1890,10 @@
                 },
                 "munich_germany": {
                     "bbox": {
-                        "top": "48.523",
-                        "left": "10.799",
-                        "bottom": "47.717",
-                        "right": "12.178"
+                        "top": "48.248",
+                        "left": "11.359",
+                        "bottom": "48.061",
+                        "right": "11.723"
                     }
                 },
                 "nancy_france": {

--- a/cities.json
+++ b/cities.json
@@ -1688,6 +1688,14 @@
                         "right": "10.678"
                     }
                 },
+                "hof_germany": {
+                    "bbox": {
+                        "top": "50.355",
+                        "left": "11.806",
+                        "bottom": "50.267",
+                        "right": "11.972"
+                    }
+                },
                 "jena_germany": {
                     "bbox": {
                         "top": "50.988",

--- a/cities.json
+++ b/cities.json
@@ -2072,6 +2072,14 @@
                         "right": "8.078"
                     }
                 },
+                "stuttgart_germany": {
+                    "bbox": {
+                        "top": "48.866",
+                        "left": "9.037",
+                        "bottom": "48.691",
+                        "right": "9.316"
+                    }
+                },
                 "the-hague_netherlands": {
                     "bbox": {
                         "top": "52.136",

--- a/cities.json
+++ b/cities.json
@@ -1488,6 +1488,14 @@
                         "right": "3.220"
                     }
                 },
+                "coburg_germany": {
+                    "bbox": {
+                        "top": "50.299",
+                        "left": "10.886",
+                        "bottom": "50.221",
+                        "right": "11.063"
+                    }
+                },
                 "copenhagen_denmark": {
                     "bbox": {
                         "top": "55.950",


### PR DESCRIPTION
Towns to be added: 

* Augsburg
* Bamberg
* Coburg
* Deggendorf
* Freiburg
* Heilbronn
* Hof
* Ingolstadt
* Konstanz
* Passau
* Stuttgart
* Regensburg
* Ulm
* Würzburg

Boundaries edited:

* München
* Nürnberg

In addition to that I removed some unnecessary whitespace or harmonized indentation by replacing tabs with spaces.