### PR TITLE
Duplicate cities

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -2308,7 +2308,7 @@
                 "turin_italy": {
                     "bbox": {
                         "top": "45.174",
-                        "left": "7.521",
+                        "left": "7.504",
                         "bottom": "44.943",
                         "right": "7.887"
                     }
@@ -3197,14 +3197,6 @@
                         "left": "11.022",
                         "bottom": "45.977",
                         "right": "11.196"
-                    }
-                },
-                "turin_italy": {
-                    "bbox": {
-                        "top": "45.156",
-                        "left": "7.504",
-                        "bottom": "44.980",
-                        "right": "7.775"
                     }
                 },
                 "valencia_spain": {

--- a/spec/duplicates_spec.rb
+++ b/spec/duplicates_spec.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env rake
+
+require 'json'
+require 'rainbow/ext/string'
+require 'set'
+
+namespace :test do
+  desc 'Check for duplicates'
+  task :duplicates do
+    puts 'Checking cities.json for duplicate names'.color(:blue)
+
+    names_seen = Set.new
+    json = JSON.parse(CitiesJSON)
+    json['regions'].each_value do |region|
+      region['cities'].each_key do |city|
+        if names_seen.include?(city)
+          abort "Failure! City with name #{city.inspect} appears twice.".color(:red)
+        else
+          names_seen.add(city)
+        end
+      end
+    end
+    puts 'OK'.color(:green)
+  end
+end

--- a/spec/duplicates_spec.rb
+++ b/spec/duplicates_spec.rb
@@ -14,7 +14,7 @@ namespace :test do
     json['regions'].each_value do |region|
       region['cities'].each_key do |city|
         if names_seen.include?(city)
-          abort "Failure! City with name #{city.inspect} appears twice.".color(:red)
+          abort "Failure! City with name #{city.inspect} already appear in cities.json, did you mean to edit the existing city's properties?".color(:red)
         else
           names_seen.add(city)
         end

--- a/tasks/test.rb
+++ b/tasks/test.rb
@@ -9,4 +9,5 @@ task :test do
   Rake::Task['test:json'].invoke
   Rake::Task['test:whitespace'].invoke
   Rake::Task['test:geojson'].invoke
+  Rake::Task['test:duplicates'].invoke
 end


### PR DESCRIPTION
I noticed that Turin, Italy appears twice in `cities.json`. This PR removes the duplicate and expands the bounding box of the remaining copy so that it covers both original bounding boxes.

This PR also adds a test so that it's easier to spot these in the future.
