### PR TITLE
Fix typo in city, plus add two major cities in Mexico

### DIFF
--- a/cities.json
+++ b/cities.json
@@ -5125,6 +5125,14 @@
                         "right": "-123.020"
                     }
                 },
+		"veracruz_veracruz_mexico": {
+		    "bbox": {
+			"top": "19.238",
+                        "left": "-96.253",
+                        "bottom": "19.065",
+                        "right": "-96.086"
+                    }
+		},
                 "victoria_canada": {
                     "bbox": {
                         "top": "48.871",
@@ -5181,6 +5189,14 @@
                         "right":"-96.885"
                     }
                 },
+		"xalapa_veracruz_mexico": {
+		    "bbox": {
+			"top": "19.604",
+                        "left": "-96.983",
+                        "bottom": "19.441",
+                        "right": "-96.833"
+                    }
+		},
                 "yellowknife_canada":{
                     "bbox":{
                         "top":"62.526",

--- a/cities.json
+++ b/cities.json
@@ -4069,7 +4069,7 @@
                         "right": "-87.237"
                     }
                 },
-                "exatepec-de-morelos_mexico": {
+                "ecatepec-de-morelos_mexico": {
                     "bbox": {
                         "top": "19.659",
                         "left": "-99.101",


### PR DESCRIPTION
Ecatepec was listed as "exatepec-de-morelos_mexico"; changed the x for c :)

Added the cities of Xalapa and Veracruz.